### PR TITLE
Chore: 도커 빌드 단계 jOOQ 실행 환경 변수 수정

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
           generate-summary: true
 
       - name: 커버리지 뱃지 커밋
-        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           if [[ `git status --porcelain` ]]; then
             git config --global user.name 'kjyy08'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -215,10 +215,8 @@ tasks.withType<Test>().configureEach {
     finalizedBy(tasks.jacocoTestReport)
 }
 
-tasks.compileKotlin {
-    if (System.getenv("DOCKER_BUILD").isNullOrEmpty()) {
-        dependsOn("generateJooqClasses")
-    }
+tasks.named("generateJooqClasses") {
+    enabled = System.getenv("DOCKER_BUILD").isNullOrEmpty()
 }
 
 tasks.clean {


### PR DESCRIPTION
## 📝작업 내용

- 테스트 커버리지 커밋 뱃지 생성 단계 대상 브랜치를 `develop`에서 `main`으로 변경

- 도커 빌드 단계에서 필요한 jOOQ 환경 변수 관련 gradle 세팅 일부 수정

## ✅ 체크리스트

- [ ] 코드 점검 완료했습니다
- [ ] 문서/주석 최신화 완료했습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- CI
  - Coverage badge update now commits only on the main branch, aligning automated badge updates with production-ready builds.
- Chores
  - Build configuration adjusted: JOOQ class generation is now enabled/disabled via the DOCKER_BUILD environment variable and is no longer coupled to Kotlin compilation, simplifying local vs. containerized builds.

No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->